### PR TITLE
Update RE5 - Maturity Level.md

### DIFF
--- a/RE5 - Maturity Level.md
+++ b/RE5 - Maturity Level.md
@@ -632,7 +632,7 @@ then
 ``` al
 if 
     previous project level is E5. Development Unclarified
-    project level is E3. Justified for Development
+    project level is E5. Development Unclarified
 
 then 
     validation result is True
@@ -3127,7 +3127,7 @@ The following equation must be true:
 
 $$
 M_s = \lbrace E_0, E_1, E_4, E_7 \rbrace\\
-M_{t_R} \notin M_s \implies  t_{act} \notin \empty
+M_{t_R} \notin M_s \implies t_{act} \notin \emptyset
 $$
 
 ```python

--- a/RE5 - Maturity Level.md
+++ b/RE5 - Maturity Level.md
@@ -2875,7 +2875,7 @@ The following equation must be true:
 
 $$
 M_s = \lbrace E_1, E_2, E_3 \rbrace\\
-\left( \Delta N_{ps}^{\text{ 1P}} > 0 \right) \lor \left(\Delta N_{ps}^{c \text{ 1P}} > 0 \right) \lor \left(\Delta G_{ps}^{a \text{ 1P}} > 0 \right) \lor \left(\Delta G_{ps}^{\text{1P}} > 0 \right) \implies M_{t_R} \in M_s
+M_{t_R} \in M_s \implies \left( \left( \Delta N_{ps}^{\text{ 1P}} > 0 \right) \lor \left(\Delta N_{ps}^{c \text{ 1P}} > 0 \right) \lor \left(\Delta G_{ps}^{a \text{ 1P}} > 0 \right) \lor \left(\Delta G_{ps}^{\text{1P}} > 0 \right) \right)
 $$
 
 ```python


### PR DESCRIPTION
RE5011 - wrong example that should pass. Fixing this with the right example

RE5066 - wrong formula. The existing formula mentioning that if the project's current maturity level is NOT in the set {E0, E1, E4, E7} then it must have on stream date (on stream date cannot be empty). The fixed formula says that IF the project is E0, E1, E4, and E7, then it MUST have on stream date.